### PR TITLE
bugfix: enable using non-default stemmers and stopwords after package name changes

### DIFF
--- a/src/main/java/com/entopix/maui/main/MauiModelBuilder.java
+++ b/src/main/java/com/entopix/maui/main/MauiModelBuilder.java
@@ -408,14 +408,14 @@ public class MauiModelBuilder implements OptionHandler {
 
 		String stopwordsString = Utils.getOption('s', options);
 		if (stopwordsString.length() > 0) {
-			stopwordsString = "maui.stopwords.".concat(stopwordsString);
+			stopwordsString = "com.entopix.maui.stopwords.".concat(stopwordsString);
 			this.stopwords = (Stopwords) Class.forName(stopwordsString)
 					.newInstance();
 		}
 
 		String stemmerString = Utils.getOption('t', options);
 		if (stemmerString.length() > 0) {
-			stemmerString = "maui.stemmers.".concat(stemmerString);
+			stemmerString = "com.entopix.maui.stemmers.".concat(stemmerString);
 			this.stemmer = (Stemmer) Class.forName(stemmerString).newInstance();
 		}
 		this.serialize = Utils.getFlag('z', options);


### PR DESCRIPTION
This is the error I got before this change:

ERROR MauiModelBuilder - Error running MauiModelBuilder..
java.lang.ClassNotFoundException: maui.stopwords.StopwordsFinnish
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at com.entopix.maui.main.MauiModelBuilder.setOptions(MauiModelBuilder.java:412)
	at com.entopix.maui.main.MauiModelBuilder.main(MauiModelBuilder.java:624)

Package names have changed, but the code was trying to load stopword/stemmer classes with the old package name.