### PR TITLE
New SKOS parser using Jena Resource API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>org.apache.jena</groupId>
 			<artifactId>jena-core</artifactId>
-			<version>2.11.2</version>
+			<version>3.6.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>log4j</groupId>

--- a/src/main/java/com/entopix/maui/vocab/Vocabulary.java
+++ b/src/main/java/com/entopix/maui/vocab/Vocabulary.java
@@ -301,10 +301,6 @@ public class Vocabulary {
 				//						children.get(name).add(id_string);
 				//				}
 
-				vocabStore.addRelationship(id_string, name, rel);
-				if (rel == Relation.kRelationRelated) {
-					vocabStore.addRelationship(name, id_string, rel);
-				}
 			}
 		}
 

--- a/src/main/java/com/entopix/maui/vocab/Vocabulary.java
+++ b/src/main/java/com/entopix/maui/vocab/Vocabulary.java
@@ -13,13 +13,13 @@ import java.util.zip.GZIPInputStream;
 import com.entopix.maui.stemmers.Stemmer;
 import com.entopix.maui.stopwords.Stopwords;
 
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.rdf.model.Property;
-import com.hp.hpl.jena.rdf.model.RDFNode;
-import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.rdf.model.Statement;
-import com.hp.hpl.jena.rdf.model.StmtIterator;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/entopix/maui/vocab/Vocabulary.java
+++ b/src/main/java/com/entopix/maui/vocab/Vocabulary.java
@@ -200,11 +200,13 @@ public class Vocabulary {
 
 			// preferred label
 			stmt = concept.getProperty(SKOS.prefLabel, this.language);
-			Literal descriptor = stmt.getLiteral();
-			String descriptorNormalized = normalizePhrase(descriptor.getLexicalForm());
-			if (descriptorNormalized.length() >= 1) {
-				vocabStore.addSense(descriptorNormalized, id_string);
-				vocabStore.addDescriptor(id_string, descriptor.getLexicalForm());
+			if (stmt != null) {
+				Literal descriptor = stmt.getLiteral();
+				String descriptorNormalized = normalizePhrase(descriptor.getLexicalForm());
+				if (descriptorNormalized.length() >= 1) {
+					vocabStore.addSense(descriptorNormalized, id_string);
+					vocabStore.addDescriptor(id_string, descriptor.getLexicalForm());
+				}
 			}
 
 			// alternate and hidden labels

--- a/src/main/java/com/entopix/maui/vocab/Vocabulary.java
+++ b/src/main/java/com/entopix/maui/vocab/Vocabulary.java
@@ -19,8 +19,10 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.SKOS;
 import org.slf4j.Logger;
@@ -186,6 +188,8 @@ public class Vocabulary {
 
 		ResIterator iter;
 		Statement stmt;
+		// for some reason Jena doesn't predefine the owl:deprecated property
+		Property owlDeprecated = ResourceFactory.createProperty(OWL.NS, "deprecated");
 
 		// to create IDs for non-descriptors!
 		int count = 0;
@@ -194,6 +198,14 @@ public class Vocabulary {
 
 		while (iter.hasNext()) {
 			Resource concept = iter.nextResource();
+
+			// check whether it's deprecated
+			stmt = concept.getProperty(owlDeprecated);
+			if (stmt != null) {
+				if (stmt.getBoolean() == true) {
+					continue; // skip deprecated concept
+				}
+			}
 
 			// id of the concept (Resource), e.g. "c_4828"
 			String id_string = concept.getURI();

--- a/src/main/java/com/entopix/maui/vocab/VocabularyStore.java
+++ b/src/main/java/com/entopix/maui/vocab/VocabularyStore.java
@@ -42,8 +42,6 @@ public abstract class VocabularyStore {
 
     public abstract void addRelatedTerm( String term, String relatedTerm );
 
-    public abstract void addRelationship( String id_string, String name, Vocabulary.Relation rel);
-
     public abstract int getNumTerms();
 
     public abstract int getNumNonDescriptors();

--- a/src/main/java/com/entopix/maui/vocab/VocabularyStore_HT.java
+++ b/src/main/java/com/entopix/maui/vocab/VocabularyStore_HT.java
@@ -24,8 +24,6 @@ public class VocabularyStore_HT extends VocabularyStore implements Externalizabl
 	private HashMap<Integer, Integer> nonDescriptorIndex = null;
 	/** id -->  list of related ids */
 	private HashMap<Integer, ArrayList<Integer>> listsOfRelatedTerms = null;
-	/** id-relatedId --> relation */
-	private HashMap<Long, Vocabulary.Relation> relationIndex = null;
 	private int currentID = 0;
 	private HashMap<String, Integer> URItoIDMap = null;
 	private HashMap<Integer, String> IDtoURIMap = null;
@@ -73,7 +71,6 @@ public class VocabularyStore_HT extends VocabularyStore implements Externalizabl
 
 		nonDescriptorIndex = new HashMap<Integer, Integer>();
 		listsOfRelatedTerms = new HashMap<Integer, ArrayList<Integer>>();
-		relationIndex = new HashMap<Long, Vocabulary.Relation>();
 	}
 
 	public void addSense(String descriptor, String id_string) {
@@ -230,15 +227,6 @@ public class VocabularyStore_HT extends VocabularyStore implements Externalizabl
 			}
 		}
 
-		/** id-relatedId --> relation */
-		out.writeInt(relationIndex.size());
-
-		for (Map.Entry<Long, Vocabulary.Relation> e : relationIndex.entrySet()) {
-			out.writeLong(e.getKey());
-			out.writeObject(e.getValue());
-		}
-
-
 		out.writeInt(IDtoURIMap.size());
 
 		for (Map.Entry<Integer, String> e : IDtoURIMap.entrySet()) {
@@ -297,17 +285,6 @@ public class VocabularyStore_HT extends VocabularyStore implements Externalizabl
 			}
 			listsOfRelatedTerms.put(term, relations);
 		}
-
-		/** id-relatedId --> relation */
-		size = in.readInt();
-
-		relationIndex = new HashMap<Long, Vocabulary.Relation>();
-		for (int i = 0; i < size; i++) {
-			Long id = in.readLong();
-			Vocabulary.Relation rel = (Vocabulary.Relation) in.readObject();
-			relationIndex.put(id, rel);
-		}
-
 
 		size = in.readInt();
 

--- a/src/main/java/com/entopix/maui/vocab/VocabularyStore_HT.java
+++ b/src/main/java/com/entopix/maui/vocab/VocabularyStore_HT.java
@@ -112,10 +112,6 @@ public class VocabularyStore_HT extends VocabularyStore implements Externalizabl
 		listsOfRelatedTerms.put(term_id, related_terms);
 	}
 
-	public void addRelationship(String id_string, String name, Vocabulary.Relation rel) {
-		//      relationIndex.put(CantorPairingFunction(createIDFromURI(id_string), createIDFromURI(name)), rel);
-	}
-
 	public int getNumTerms() {
 		return idTermIndex.size();
 	}

--- a/src/main/java/com/entopix/maui/vocab/VocabularyStore_Original.java
+++ b/src/main/java/com/entopix/maui/vocab/VocabularyStore_Original.java
@@ -68,10 +68,6 @@ public class VocabularyStore_Original extends VocabularyStore implements Externa
 		listsOfRelatedTerms.put(term, related_terms);
 	}
 
-	public void addRelationship(String id_string, String name, Vocabulary.Relation rel){
-		// relationIndex.put(id_string+"-"+ name, rel);
-	}
-
 	public int getNumTerms() {
 		return idTermIndex.size();
 	}

--- a/src/main/java/com/entopix/maui/vocab/VocabularyStore_Original.java
+++ b/src/main/java/com/entopix/maui/vocab/VocabularyStore_Original.java
@@ -25,8 +25,6 @@ public class VocabularyStore_Original extends VocabularyStore implements Externa
 	private HashMap<String, String> nonDescriptorIndex = null;
 	/** id -->  list of related ids */
 	private HashMap<String, ArrayList<String>> listsOfRelatedTerms = null;
-	/** id-relatedId --> relation */
-	private HashMap<String, Vocabulary.Relation> relationIndex = null;
 
 
 
@@ -37,7 +35,6 @@ public class VocabularyStore_Original extends VocabularyStore implements Externa
 
 		nonDescriptorIndex = new HashMap<String, String>();
 		listsOfRelatedTerms = new HashMap<String, ArrayList<String>>();
-		relationIndex = new HashMap<String, Vocabulary.Relation>();
 	}
 
 	public void addSense(String descriptor, String id) {
@@ -165,14 +162,6 @@ public class VocabularyStore_Original extends VocabularyStore implements Externa
 			}
 		}
 
-		/** id-relatedId --> relation */
-		out.writeInt(relationIndex.size());
-
-		for (Map.Entry<String, Vocabulary.Relation> e : relationIndex.entrySet()) {
-			out.writeUTF(e.getKey());
-			out.writeObject(e.getValue());
-		}
-
 	}
 
 	public void readExternal(ObjectInput in) throws java.io.IOException, ClassNotFoundException {
@@ -219,16 +208,6 @@ public class VocabularyStore_Original extends VocabularyStore implements Externa
 				relations.add(in.readUTF());
 			}
 			listsOfRelatedTerms.put(term, relations);
-		}
-
-		/** id-relatedId --> relation */
-		size = in.readInt();
-
-		relationIndex = new HashMap<String, Vocabulary.Relation>(size);
-		for (int i = 0; i < size; i++) {
-			String id = in.readUTF();
-			Vocabulary.Relation rel = (Vocabulary.Relation) in.readObject();
-			relationIndex.put(id, rel);
 		}
 
 		finishedInitialized();


### PR DESCRIPTION
This PR replaces the existing Jena-based SKOS parser with a new implementation. The old parser goes through the SKOS file triple-by-triple and generates the corresponding VocabularyStore data structures. The old code has the following limitations:

* it is unnecessarily complex and doesn't make good use of the Jena API, instead preferring to walk through the RDF triples one by one
* it may add SKOS Collections to the vocabulary, even though they should not be used for subject indexing
* it doesn't check for deprecated concepts, which is a fairly common pattern in SKOS datasets (e.g. STW Thesaurus and YSO use it)

The new implementation:
* is much simpler than the original and uses resource-centric Jena API idioms
* only adds SKOS Concept instances to the vocabulary, avoiding e.g. Collections
* checks for deprecated concepts

This PR updates the Jena dependency to the most recent release 3.6.0. It also removes some dead code from the VocabularyStore implementations - the relationship index was never populated in the first place.

I get ~0.5 percentage point improvement on the F-Measure of my "kirjastonhoitaja" data set using YSO. The improvement is due to avoiding deprecated concepts.