### PR TITLE
Revert default VocabularyStore to Original class

### DIFF
--- a/src/main/java/com/entopix/maui/vocab/VocabularyStoreFactory.java
+++ b/src/main/java/com/entopix/maui/vocab/VocabularyStoreFactory.java
@@ -19,12 +19,12 @@ import com.entopix.maui.stemmers.Stemmer;
  * @author nathanholmberg, zelandiya
  */
 public class VocabularyStoreFactory {
-    
+
     private static final Logger log = LoggerFactory.getLogger(VocabularyStoreFactory.class);
 
     @SuppressWarnings("rawtypes")
-    public static final Class DEFAULT_VOCABULARY_CLASS = VocabularyStore_HT.class;
-    
+    public static final Class DEFAULT_VOCABULARY_CLASS = VocabularyStore_Original.class;
+
     private static String filenameForVocabulary(String vocabularyName, Stemmer stemmer, @SuppressWarnings("rawtypes") Class vocabularyClass) {
         return vocabularyName + "_" + vocabularyClass.getName() + "_" + stemmer.getClass().getSimpleName() + ".serialized";
     }
@@ -32,7 +32,7 @@ public class VocabularyStoreFactory {
     public static VocabularyStore createVocabStore(String vocabularyName, Stemmer stemmer, boolean serialize) {
     	return createVocabStore(vocabularyName, stemmer, serialize, DEFAULT_VOCABULARY_CLASS);
     }
-    
+
     public static VocabularyStore createVocabStore(String vocabularyName, Stemmer stemmer, boolean serialize, @SuppressWarnings("rawtypes")Class vocabularyClass) {
         VocabularyStore vocab_store = null;
         if (serialize) {

--- a/src/test/java/com/entopix/maui/main/VocabularyTest.java
+++ b/src/test/java/com/entopix/maui/main/VocabularyTest.java
@@ -1,0 +1,68 @@
+package com.entopix.maui.main;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.entopix.maui.vocab.Vocabulary;
+
+public class VocabularyTest {
+
+	private Vocabulary vocabulary  = new Vocabulary();
+
+	@Before
+	public void loadVocabulary() throws Exception {
+		// Vocabulary
+		// agrovoc root URI is "http://www.fao.org/aos/agrovoc#"
+		String vocabularyFormat = "skos";
+		String vocabularyPath = "src/test/resources/data/vocabularies/agrovoc_sample.rdf";
+		vocabulary.initializeVocabulary(vocabularyPath, vocabularyFormat);
+
+		//System.out.println("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-");
+		//System.out.println(vocabulary.getVocabularyStore().getClass().getName());
+	}
+
+	/*
+	 * 1. Test term with loaded URI
+	 */
+	@Test
+	public void testURI() {
+		String uri = "http://www.fao.org/aos/agrovoc#c_165";
+		String term = "Africa";
+
+		assertEquals(term, vocabulary.getTerm(uri));
+		assertEquals(uri, vocabulary.getSenses(term).get(0));
+	}
+
+	/*
+	 * 2. Test term with different root URI
+	 */
+	@Test
+	public void testRootURI() {
+		String uri = "https://test.ing/12345";
+		String term = "antidisestablishmentarianism";
+
+		vocabulary.getVocabularyStore().addDescriptor(uri, term);
+		vocabulary.getVocabularyStore().addSense(term, uri);
+
+		assertEquals(term, vocabulary.getTerm(uri));
+		assertEquals(uri, vocabulary.getSenses(term).get(0));
+	}
+
+	/*
+	 * 3. Test term with URN
+	 */
+	@Test
+	public void testURN() {
+		String uri = "urn:isbn:1234567890";
+		String term = "supercalifragilisticexpialidocious";
+
+		vocabulary.getVocabularyStore().addDescriptor(uri, term);
+		vocabulary.getVocabularyStore().addSense(term, uri);
+
+		assertEquals(term, vocabulary.getTerm(uri));
+		assertEquals(uri, vocabulary.getSenses(term).get(0));
+	}
+
+}


### PR DESCRIPTION
This PR is a proposed solution to https://github.com/NatLibFi/maui/issues/5; it includes a small suite of tests.

Reverting to VocabularyStore_Original as the default class maintains the same code base, while reducing complexity and solving these bugs.  The major downside I can see is potential (likely) increased memory usage, but not enough to be inhibitive.

Otherwise, I expect a much more significant refactor to VocabularyStore_HT would be required.