### PR TITLE
Fix handling of multiple URI prefixes in VocabularyStore_HT

### DIFF
--- a/src/main/java/com/entopix/maui/vocab/VocabularyStore_HT.java
+++ b/src/main/java/com/entopix/maui/vocab/VocabularyStore_HT.java
@@ -42,6 +42,7 @@ public class VocabularyStore_HT extends VocabularyStore implements Externalizabl
 		} else if (prefix_current.equals(conceptURIPrefix)) {
 			in = in.substring(prefix_current.length());
 		} else {
+			in = "<" + in + ">";
 			// log.info("Not saving anything by cutting off prefix?");
 		}
 
@@ -61,7 +62,11 @@ public class VocabularyStore_HT extends VocabularyStore implements Externalizabl
 	}
 
 	public String createURIFromID(Integer id) {
-		return conceptURIPrefix + IDtoURIMap.get(id);
+		String localName = IDtoURIMap.get(id);
+		if (localName.startsWith("<")) {
+			return localName.substring(1, localName.length()-1);
+		}
+		return conceptURIPrefix + localName;
 	}
 
 	public VocabularyStore_HT() {

--- a/src/test/java/com/entopix/maui/main/VocabularyTest.java
+++ b/src/test/java/com/entopix/maui/main/VocabularyTest.java
@@ -1,0 +1,68 @@
+package com.entopix.maui.main;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.entopix.maui.vocab.Vocabulary;
+
+public class VocabularyTest {
+
+	private Vocabulary vocabulary  = new Vocabulary();
+
+	@Before
+	public void loadVocabulary() throws Exception {
+		// Vocabulary
+		// agrovoc root URI is "http://www.fao.org/aos/agrovoc#"
+		String vocabularyFormat = "skos";
+		String vocabularyPath = "src/test/resources/data/vocabularies/agrovoc_sample.rdf";
+		vocabulary.initializeVocabulary(vocabularyPath, vocabularyFormat);
+
+		//System.out.println("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-");
+		//System.out.println(vocabulary.getVocabularyStore().getClass().getName());
+	}
+
+	/*
+	 * 1. Test term with loaded URI
+	 */
+	@Test
+	public void testURI() {
+		String uri = "http://www.fao.org/aos/agrovoc#c_165";
+		String term = "Africa";
+
+		assertEquals(term, vocabulary.getTerm(uri));
+		assertEquals(uri, vocabulary.getSenses(term).get(0));
+	}
+
+	/*
+	 * 2. Test term with different root URI
+	 */
+	@Test
+	public void testRootURI() {
+		String uri = "https://test.ing/12345";
+		String term = "antidisestablishmentarianism";
+
+		vocabulary.getVocabularyStore().addDescriptor(uri, term);
+		vocabulary.getVocabularyStore().addSense(term, uri);
+
+		assertEquals(term, vocabulary.getTerm(uri));
+		assertEquals(uri, vocabulary.getSenses(term).get(0));
+	}
+
+	/*
+	 * 3. Test term with URN
+	 */
+	@Test
+	public void testURN() {
+		String uri = "urn:isbn:1234567890";
+		String term = "supercalifragilisticexpialidocious";
+
+		vocabulary.getVocabularyStore().addDescriptor(uri, term);
+		vocabulary.getVocabularyStore().addSense(term, uri);
+
+		assertEquals(term, vocabulary.getTerm(uri));
+		assertEquals(uri, vocabulary.getSenses(term).get(0));
+	}
+
+}


### PR DESCRIPTION
This is an alternative to PR #6, fixing issue #5.

It includes the unit tests from #6 (by @mjsuhonos) but instead of switching to VocabularyStore_Orig as #6 did, the problem in VocabularyStore_HT is addressed by storing the URIs that don't match the expected prefix within angle brackets, so that they can then be properly decoded. Since unencoded angle brackets are not valid characters in URIs, there should be no possibility for confusion.

Would you like to try this @mjsuhonos and check whether it fixes your original problem?