### PR TITLE
Add a NoStopwords class. Fixes #4

### DIFF
--- a/src/main/java/com/entopix/maui/stopwords/NoStopwords.java
+++ b/src/main/java/com/entopix/maui/stopwords/NoStopwords.java
@@ -1,0 +1,26 @@
+package com.entopix.maui.stopwords;
+
+import java.util.ArrayList;
+
+/**
+ * Dummy class that works like the other Stopwords classes but never
+ * identifies any word as a stopword. Can be used for languages for which
+ * no better Stopwords class exists.
+ *
+ * @author Osma Suominen (osma.suominen@helsinki.fi)
+ * @version 1.0
+ */
+public class NoStopwords extends Stopwords {
+
+    private static final long serialVersionUID = 1L;
+
+    public NoStopwords() {
+        // don't add any words to the list of stopwords
+        super(new ArrayList<String>());
+    }
+
+    @Override
+    public boolean isStopword(String word) {
+        return false;
+    }
+}

--- a/src/test/java/com/entopix/maui/main/NoStopwordsTest.java
+++ b/src/test/java/com/entopix/maui/main/NoStopwordsTest.java
@@ -1,0 +1,26 @@
+package com.entopix.maui.main;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.entopix.maui.stopwords.NoStopwords;
+import com.entopix.maui.stopwords.Stopwords;
+
+public class NoStopwordsTest {
+
+	private Stopwords stopwords;
+
+	@Before
+	public void setUp() throws Exception {
+		stopwords = new NoStopwords();
+	}
+
+	@Test
+	public void testIsStopword() {
+		assertEquals(false, stopwords.isStopword("the"));
+		assertEquals(false, stopwords.isStopword("cat"));
+	}
+
+}


### PR DESCRIPTION
This PR adds a NoStopwords class as requested by @hekl in issue #4.
It can be used when no suitable language-specific stopwords implementation exists.