### PR TITLE
Remove explicit check for parentheses in descriptors

### DIFF
--- a/src/main/java/com/entopix/maui/vocab/VocabularyStore_HT.java
+++ b/src/main/java/com/entopix/maui/vocab/VocabularyStore_HT.java
@@ -169,12 +169,7 @@ public class VocabularyStore_HT extends VocabularyStore implements Externalizabl
 					continue;
 				}
 				if (!senses.contains(senseId)) {
-					// if ambiguous sense, check if there's a nonambiguous one.
-					// helps with LCSHs!
-					String nonambig = idTermIndex.get(senseId);
-					if (nonambig.indexOf('(') == -1) {
-						senses.add(senseId);
-					}
+					senses.add(senseId);
 				}
 			}
 		}


### PR DESCRIPTION
This PR removes the explicit check for parentheses in descriptors (prefLabels) that prevents Maui from matching text to terms with parenthetical qualifiers.
Fixes #13